### PR TITLE
Change method signature for Behat's WebContext

### DIFF
--- a/src/Resources/Behat/WebContext.php
+++ b/src/Resources/Behat/WebContext.php
@@ -18,10 +18,10 @@ class WebContext extends MinkContext
     }
 
     /**
-     * @When I visit :arg1
+     * @When I visit :url
      */
-    public function iVisit(string $page)
+    public function iVisit(string $url)
     {
-        $this->visit($page);
+        $this->visit($url);
     }
 }


### PR DESCRIPTION
The @When I visit method's parameter now reflects the method's use -
it's visiting a url, which makes more sense than just :arg1.

Closes #42 .