### PR TITLE
Fix Behat steps and scenarios that were failing on multiple runs

### DIFF
--- a/features/FOS-check-user-can-0-register.feature
+++ b/features/FOS-check-user-can-0-register.feature
@@ -4,7 +4,8 @@ Feature: Register new user
   I need to be able to register with the site
 
   Scenario: As an ordinary visitor, I should be able to register with the site
-    Given I am on "/register/"
+    Given there is no user with username "tomo.omot"
+    And I am on "/register/"
     When I fill in "fos_user_registration_form[email]" with "hcs@omot.com"
     And I fill in "fos_user_registration_form[username]" with "tomo.omot"
     And I fill in "fos_user_registration_form[plainPassword][first]" with "12345"

--- a/src/Resources/Behat/WebContext.php
+++ b/src/Resources/Behat/WebContext.php
@@ -39,10 +39,20 @@ class WebContext extends MinkContext implements KernelAwareContext
         $airportRepository = $this->getService('aviation.repository.airports');
         $airports          = $airportRepository->findByName($airportName);
 
-        if (null !== $airports) {
-            $em = $this->getEntityManager();
+        $flightRepository = $this->getService('aviation.repository.flights');
 
+        if (null !== $airports) {
             foreach ($airports as $airport) {
+                $departingFlights = $flightRepository->findByDepartureAirport($airport);
+                $arrivingFlights  = $flightRepository->findByArrivalAirport($airport);
+
+                foreach ($departingFlights as $departingFlight) {
+                    $this->delete($departingFlight);
+                }
+
+                foreach ($arrivingFlights as $arrivingFlight) {
+                    $this->delete($arrivingFlight);
+                }
                 $this->delete($airport);
             }
         }
@@ -147,5 +157,19 @@ class WebContext extends MinkContext implements KernelAwareContext
 
         $userManager->deleteUser($admin_tester);
         $userManager->deleteUser($user_tester);
+    }
+
+    /**
+     * @Given there is no user with username :username
+     */
+    public function thereIsNoUserWithUsername($username)
+    {
+        $userManager = $this->getContainer()->get('fos_user.user_manager');
+
+        $user = $userManager->findUserByUsername($username);
+
+        if (null !== $user) {
+            $userManager->deleteUser($user);
+        }
     }
 }


### PR DESCRIPTION
Some steps caused scenarios to fail on multiple runs, because they
were trying to either delete from db, or insert data that was already
there.