### PR TITLE
Fix bugs that were causing some behat tests to fail on multiple runs

### DIFF
--- a/features/add-new-airport.feature
+++ b/features/add-new-airport.feature
@@ -3,16 +3,17 @@ Feature: Add new airport
   As an airport employee
   I need to add an airport
 
-  Scenario: There is a link to add new airport on airports page
+  Background:
     Given I am authenticated as "admin_tester"
-    And I am on "/airport/"
+
+  Scenario: There is a link to add new airport on airports page
+    Given I am on "/airport/"
     When I click "Create a new airport"
     Then I should see "Airport creation"
 
 
   Scenario: Add new airport
-    Given I am authenticated as "admin_tester"
-    And I am on "/airport/new"
+    Given I am on "/airport/new"
     And there is no airport named "Pleso"
     When I fill in "aviation_airlinesbundle_airport[name]" with "Pleso"
     And I fill in "aviation_airlinesbundle_airport[location]" with "Pleso Location PL-H311"


### PR DESCRIPTION
Some behat tests were failing on multiple runs because they were trying to delete or insert into db when records were already present, or were referenced by foreign keys in other tables.

We're now performing safe deletes - i.e. we're deleting referenced records automatically, by code, instead of relying on FK Constraints.

Some tests/scenarios got a touch up.